### PR TITLE
chap8. 객체만들기

### DIFF
--- a/src/main/java/com/tdd/domain/Franc.java
+++ b/src/main/java/com/tdd/domain/Franc.java
@@ -9,7 +9,10 @@ public class Franc extends Money {
         this.amount = amount;
     }
 
-    public Franc times(final int multiplier) {
+    /**
+     * 곱수에 곱하기한 Franc객체 생성.
+     */
+    public Money times(final int multiplier) {
         return new Franc(amount * multiplier);
     }
 }

--- a/src/main/java/com/tdd/domain/Money.java
+++ b/src/main/java/com/tdd/domain/Money.java
@@ -3,12 +3,22 @@ package com.tdd.domain;
 /**
  * Created by seongjuhyeon on 12/1/15.
  */
-public class Money {
+public abstract class Money {
 
     protected int amount;
 
     public boolean equals(Object object) {
         Money money = (Money) object;
         return amount == money.amount && getClass().equals(money.getClass());
+    }
+
+    public static Money dollar(int amount) {
+        return new Dollar(amount);
+    }
+
+    public abstract Money times(int multiplier);
+
+    public static Money franc(int amount) {
+        return new Franc(amount);
     }
 }

--- a/src/test/java/com/tdd/domain/DollarTest.java
+++ b/src/test/java/com/tdd/domain/DollarTest.java
@@ -13,14 +13,14 @@ public class DollarTest {
 
     @Test
     public void testMultiplication() {
-        Dollar five = new Dollar(5);
-        assertEquals(new Dollar(10), five.times(2));
-        assertEquals(new Dollar(15), five.times(3));
+        Money five = Money.dollar(5);
+        assertEquals(Money.dollar(10), five.times(2));
+        assertEquals(Money.dollar(15), five.times(3));
     }
 
     @Test
     public void testEquality() {
-        assertTrue(new Dollar(5).equals(new Dollar(5)));
-        assertFalse(new Dollar(5).equals(new Dollar(10)));
+        assertTrue(Money.dollar(5).equals(Money.dollar(5)));
+        assertFalse(Money.dollar(5).equals(Money.dollar(6)));
     }
 }

--- a/src/test/java/com/tdd/domain/FrancTest.java
+++ b/src/test/java/com/tdd/domain/FrancTest.java
@@ -13,14 +13,14 @@ public class FrancTest {
 
     @Test
     public void testFrancMultiplication () {
-        Franc five = new Franc(5);
-        assertEquals(new Franc(10), five.times(2));
-        assertEquals(new Franc(15), five.times(3));
+        Money five = Money.franc(5);
+        assertEquals(Money.franc(10), five.times(2));
+        assertEquals(Money.franc(15), five.times(3));
     }
 
     @Test
     public void testEquality() {
-        assertTrue(new Franc(5).equals(new Franc(5)));
-        assertFalse(new Franc(5).equals(new Franc(10)));
+        assertTrue(Money.franc(5).equals(Money.franc(5)));
+        assertFalse(Money.franc(5).equals(Money.franc(10)));
     }
 }

--- a/src/test/java/com/tdd/domain/MoneyTest.java
+++ b/src/test/java/com/tdd/domain/MoneyTest.java
@@ -1,26 +1,18 @@
 package com.tdd.domain;
 
-import com.tdd.domain.Dollar;
+import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertTrue;
 
 import org.junit.Test;
 
-import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertEquals;
-
-import com.tdd.domain.Dollar;
-
-/**
- * Created by seongjuhyeon on 11/21/15.
- */
 public class MoneyTest {
 
     @Test
     public void testEquals() throws Exception {
-        assertTrue(new Dollar(5).equals(new Dollar(5)));
-        assertFalse(new Dollar(5).equals(new Dollar(10)));
-        assertTrue(new Franc(5).equals(new Franc(5)));
-        assertFalse(new Franc(5).equals(new Franc(10)));
-        assertFalse(new Franc(5).equals(new Dollar(5)));
+        assertTrue(Money.dollar(5).equals(Money.dollar(5)));
+        assertFalse(Money.dollar(5).equals(Money.dollar(6)));
+        assertTrue(Money.franc(5).equals(Money.franc(5)));
+        assertFalse(Money.franc(5).equals(Money.franc(10)));
+        assertFalse(Money.franc(5).equals(Money.dollar(5)));
     }
 }


### PR DESCRIPTION
chap8. 객체만들기

- 동일한 메서드(times)의 두 변이형 메서드 서명부를 통일시킴으로써 중복 제거를 향해 한 단계 더 전진했다.
- 최소한 메서드 선언부만이라도 공통 상위 클래스(superclass)로 옮겼다.
- 팩토리 메서드를 도입하여 테스트 코드에서 콘크리트 하위 클래서의 존재 사실을 분리해냈다.
- 하위 클래스가 사라지면 몇몇 테스트는 불필요한 여분의 것이 된다는 것을 인식했다. 하지만 일단 그냥 뒀다.